### PR TITLE
Note about wrapping install in quotes for zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ To make parsing HTML faster, I've also added two popular parsing packages to Ste
 
 ```
 $ pip install stealth_requests[parsers]
+
+# Some shells, like zsh on macOS, require wrapping with quotes:
+$ pip install 'stealth_requests[parsers]'
 ```
 
 To easily get an Lxml tree, you can use `resp.tree()` and to get a BeautifulSoup object, use the `resp.soup()` method.

--- a/README.md
+++ b/README.md
@@ -89,9 +89,6 @@ print(resp.meta.title)
 To make parsing HTML faster, I've also added two popular parsing packages to Stealth-Requests - Lxml and BeautifulSoup4. To use these add-ons you need to install the `parsers` extra: 
 
 ```
-$ pip install stealth_requests[parsers]
-
-# Some shells, like zsh on macOS, require wrapping with quotes:
 $ pip install 'stealth_requests[parsers]'
 ```
 


### PR DESCRIPTION
Added a small note to point out installing parsers on some shells require the package to be wrapped in quotes.