### PR TITLE
fix: handle empty xpath result in markdown() to avoid IndexError

### DIFF
--- a/stealth_requests/response.py
+++ b/stealth_requests/response.py
@@ -124,7 +124,10 @@ class StealthResponse:
 
         tree = self.tree()
         if content_xpath:
-            tree = tree.xpath(content_xpath)[0]
+            results = tree.xpath(content_xpath)
+            if not results:
+                return ""
+            tree = results[0]
         html = etree.tostring(tree, pretty_print=True, method='html').decode()
 
         return text_maker.handle(html)


### PR DESCRIPTION
When you call `response.markdown(content_xpath='//article')` and the page doesn't contain an `<article>` element, it currently crashes with an unhandled exception:

```
IndexError: list index out of range
```

This happens because `tree.xpath(content_xpath)` returns an empty list, and `[0]` on an empty list raises `IndexError`.

Fix: check the result before indexing. If the xpath matches nothing, return an empty string instead of crashing.

```python
# Before
if content_xpath:
    tree = tree.xpath(content_xpath)[0]

# After
if content_xpath:
    results = tree.xpath(content_xpath)
    if not results:
        return ""
    tree = results[0]
```

This is a pretty common pattern when scraping pages where a specific section may or may not exist.